### PR TITLE
Chore/order tracking

### DIFF
--- a/assets/js/user_socket.js
+++ b/assets/js/user_socket.js
@@ -1,0 +1,64 @@
+// NOTE: The contents of this file will only be executed if
+// you uncomment its entry in "assets/js/app.js".
+
+// Bring in Phoenix channels client library:
+import {Socket} from "phoenix"
+
+// And connect to the path in "lib/plate_slate_web/endpoint.ex". We pass the
+// token for authentication. Read below how it should be used.
+let socket = new Socket("/socket", {params: {token: window.userToken}})
+
+// When you connect, you'll often need to authenticate the client.
+// For example, imagine you have an authentication plug, `MyAuth`,
+// which authenticates the session and assigns a `:current_user`.
+// If the current user exists you can assign the user's token in
+// the connection for use in the layout.
+//
+// In your "lib/plate_slate_web/router.ex":
+//
+//     pipeline :browser do
+//       ...
+//       plug MyAuth
+//       plug :put_user_token
+//     end
+//
+//     defp put_user_token(conn, _) do
+//       if current_user = conn.assigns[:current_user] do
+//         token = Phoenix.Token.sign(conn, "user socket", current_user.id)
+//         assign(conn, :user_token, token)
+//       else
+//         conn
+//       end
+//     end
+//
+// Now you need to pass this token to JavaScript. You can do so
+// inside a script tag in "lib/plate_slate_web/templates/layout/app.html.heex":
+//
+//     <script>window.userToken = "<%= assigns[:user_token] %>";</script>
+//
+// You will need to verify the user token in the "connect/3" function
+// in "lib/plate_slate_web/channels/user_socket.ex":
+//
+//     def connect(%{"token" => token}, socket, _connect_info) do
+//       # max_age: 1209600 is equivalent to two weeks in seconds
+//       case Phoenix.Token.verify(socket, "user socket", token, max_age: 1_209_600) do
+//         {:ok, user_id} ->
+//           {:ok, assign(socket, :user, user_id)}
+//
+//         {:error, reason} ->
+//           :error
+//       end
+//     end
+//
+// Finally, connect to the socket:
+socket.connect()
+
+// Now that you are connected, you can join channels with a topic.
+// Let's assume you have a channel with a topic named `room` and the
+// subtopic is its id - in this case 42:
+let channel = socket.channel("room:42", {})
+channel.join()
+  .receive("ok", resp => { console.log("Joined successfully", resp) })
+  .receive("error", resp => { console.log("Unable to join", resp) })
+
+export default socket

--- a/lib/plate_slate/application.ex
+++ b/lib/plate_slate/application.ex
@@ -17,7 +17,8 @@ defmodule PlateSlate.Application do
       # Start a worker by calling: PlateSlate.Worker.start_link(arg)
       # {PlateSlate.Worker, arg},
       # Start to serve requests, typically the last entry
-      PlateSlateWeb.Endpoint
+      PlateSlateWeb.Endpoint,
+      {Absinthe.Subscription, pubsub: PlateSlateWeb.Endpoint}
     ]
 
     # See https://hexdocs.pm/elixir/Supervisor.html

--- a/lib/plate_slate/ordering.ex
+++ b/lib/plate_slate/ordering.ex
@@ -51,6 +51,7 @@ defmodule PlateSlate.Ordering do
   """
   def create_order(attrs \\ %{}) do
     attrs = Map.update(attrs, :items, [], &build_items/1)
+
     %Order{}
     |> Order.changeset(attrs)
     |> Repo.insert()

--- a/lib/plate_slate/ordering.ex
+++ b/lib/plate_slate/ordering.ex
@@ -1,0 +1,112 @@
+defmodule PlateSlate.Ordering do
+  @moduledoc """
+  The Ordering context.
+  """
+
+  import Ecto.Query, warn: false
+  alias PlateSlate.Repo
+
+  alias PlateSlate.Ordering.Order
+
+  @doc """
+  Returns the list of orders.
+
+  ## Examples
+
+      iex> list_orders()
+      [%Order{}, ...]
+
+  """
+  def list_orders do
+    Repo.all(Order)
+  end
+
+  @doc """
+  Gets a single order.
+
+  Raises `Ecto.NoResultsError` if the Order does not exist.
+
+  ## Examples
+
+      iex> get_order!(123)
+      %Order{}
+
+      iex> get_order!(456)
+      ** (Ecto.NoResultsError)
+
+  """
+  def get_order!(id), do: Repo.get!(Order, id)
+
+  @doc """
+  Creates a order.
+
+  ## Examples
+
+      iex> create_order(%{field: value})
+      {:ok, %Order{}}
+
+      iex> create_order(%{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def create_order(attrs \\ %{}) do
+    attrs = Map.update(attrs, :items, [], &build_items/1)
+    %Order{}
+    |> Order.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  def build_items(items) do
+    for item <- items do
+      menu_item = PlateSlate.Menu.get_item!(item.menu_item_id)
+      %{name: menu_item.name, quantity: item.quantity, price: menu_item.price}
+    end
+  end
+
+  @doc """
+  Updates a order.
+
+  ## Examples
+
+      iex> update_order(order, %{field: new_value})
+      {:ok, %Order{}}
+
+      iex> update_order(order, %{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def update_order(%Order{} = order, attrs) do
+    order
+    |> Order.changeset(attrs)
+    |> Repo.update()
+  end
+
+  @doc """
+  Deletes a order.
+
+  ## Examples
+
+      iex> delete_order(order)
+      {:ok, %Order{}}
+
+      iex> delete_order(order)
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def delete_order(%Order{} = order) do
+    Repo.delete(order)
+  end
+
+  @doc """
+  Returns an `%Ecto.Changeset{}` for tracking order changes.
+
+  ## Examples
+
+      iex> change_order(order)
+      %Ecto.Changeset{data: %Order{}}
+
+  """
+  def change_order(%Order{} = order, attrs \\ %{}) do
+    Order.changeset(order, attrs)
+  end
+end

--- a/lib/plate_slate/ordering/item.ex
+++ b/lib/plate_slate/ordering/item.ex
@@ -1,0 +1,16 @@
+defmodule PlateSlate.Ordering.Item do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  embedded_schema do
+    field :price, :decimal
+    field :name, :string
+    field :quantity, :integer
+  end
+
+  def changeset(item, attrs) do
+    item
+    |> cast(attrs, [:price, :name, :quantity])
+    |> validate_required([:price, :name, :quantity])
+  end
+end

--- a/lib/plate_slate/ordering/order.ex
+++ b/lib/plate_slate/ordering/order.ex
@@ -1,0 +1,22 @@
+defmodule PlateSlate.Ordering.Order do
+  use Ecto.Schema
+  import Ecto.Changeset
+  alias __MODULE__
+
+  schema "orders" do
+    field :customer_number, :integer
+    field :ordered_at, :utc_datetime
+    field :state, :string
+
+    embeds_many :items, PlateSlate.Ordering.Item
+
+    timestamps(type: :utc_datetime)
+  end
+
+  @doc false
+  def changeset(%Order{} = order, attrs) do
+    order
+    |> cast(attrs, [:customer_number, :ordered_at, :state])
+    |> cast_embed(:items)
+  end
+end

--- a/lib/plate_slate_web/channels/user_socket.ex
+++ b/lib/plate_slate_web/channels/user_socket.ex
@@ -1,0 +1,54 @@
+defmodule PlateSlateWeb.UserSocket do
+  use Phoenix.Socket
+  use Absinthe.Phoenix.Socket, schema: PlateSlateWeb.Schema
+
+  # A Socket handler
+  #
+  # It's possible to control the websocket connection and
+  # assign values that can be accessed by your channel topics.
+
+  ## Channels
+  # Uncomment the following line to define a "room:*" topic
+  # pointing to the `PlateSlateWeb.RoomChannel`:
+  #
+  # channel "room:*", PlateSlateWeb.RoomChannel
+  #
+  # To create a channel file, use the mix task:
+  #
+  #     mix phx.gen.channel Room
+  #
+  # See the [`Channels guide`](https://hexdocs.pm/phoenix/channels.html)
+  # for further details.
+
+  # Socket params are passed from the client and can
+  # be used to verify and authenticate a user. After
+  # verification, you can put default assigns into
+  # the socket that will be set for all channels, ie
+  #
+  #     {:ok, assign(socket, :user_id, verified_user_id)}
+  #
+  # To deny connection, return `:error` or `{:error, term}`. To control the
+  # response the client receives in that case, [define an error handler in the
+  # websocket
+  # configuration](https://hexdocs.pm/phoenix/Phoenix.Endpoint.html#socket/3-websocket-configuration).
+  #
+  # See `Phoenix.Token` documentation for examples in
+  # performing token verification on connect.
+  @impl true
+  def connect(_params, socket, _connect_info) do
+    {:ok, socket}
+  end
+
+  # Socket IDs are topics that allow you to identify all sockets for a given user:
+  #
+  #     def id(socket), do: "user_socket:#{socket.assigns.user_id}"
+  #
+  # Would allow you to broadcast a "disconnect" event and terminate
+  # all active sockets and channels for a given user:
+  #
+  #     Elixir.PlateSlateWeb.Endpoint.broadcast("user_socket:#{user.id}", "disconnect", %{})
+  #
+  # Returning `nil` makes this socket anonymous.
+  @impl true
+  def id(_socket), do: nil
+end

--- a/lib/plate_slate_web/endpoint.ex
+++ b/lib/plate_slate_web/endpoint.ex
@@ -1,5 +1,6 @@
 defmodule PlateSlateWeb.Endpoint do
   use Phoenix.Endpoint, otp_app: :plate_slate
+  use Absinthe.Phoenix.Endpoint
 
   # The session will be stored in the cookie and signed,
   # this means its contents can be read but not tampered with.
@@ -10,6 +11,10 @@ defmodule PlateSlateWeb.Endpoint do
     signing_salt: "agUrycpX",
     same_site: "Lax"
   ]
+
+  socket "/socket", PlateSlateWeb.UserSocket,
+    websocket: true,
+    longpoll: false
 
   socket "/live", Phoenix.LiveView.Socket,
     websocket: [connect_info: [session: @session_options]],

--- a/lib/plate_slate_web/resolvers/menu.ex
+++ b/lib/plate_slate_web/resolvers/menu.ex
@@ -17,19 +17,17 @@ defmodule PlateSlateWeb.Resolvers.Menu do
   def create_item(_, %{input: params}, _) do
     case Menu.create_item(params) do
       {:error, changeset} ->
-        {
-          :error,
-          message: "Could not create menu item", details: error_details(changeset)
-        }
+        {:ok, %{errors: transform_errors(changeset)}}
 
-      {:ok, _} = success ->
-        success
+      {:ok, menuitem} ->
+        {:ok, %{menu_item: menuitem}}
     end
   end
 
-  defp error_details(changeset) do
+  defp transform_errors(changeset) do
     changeset
     |> Ecto.Changeset.traverse_errors(&format_error/1)
+    |> Enum.map(fn {key, value} -> %{key: key, message: value} end)
   end
 
   @spec format_error(Ecto.Changeset.error()) :: String.t()

--- a/lib/plate_slate_web/resolvers/ordering.ex
+++ b/lib/plate_slate_web/resolvers/ordering.ex
@@ -3,10 +3,12 @@ defmodule PlateSlateWeb.Resolvers.Ordering do
 
   def place_order(_, %{input: place_order_input}, _) do
     case Ordering.create_order(place_order_input) do
-      {:ok, order} -> 
+      {:ok, order} ->
         Absinthe.Subscription.publish(PlateSlateWeb.Endpoint, order, new_order: "*")
         {:ok, %{order: order}}
-      {:error, changeset} -> {:ok, %{errors: transform_errors(changeset)}}
+
+      {:error, changeset} ->
+        {:ok, %{errors: transform_errors(changeset)}}
     end
   end
 
@@ -24,5 +26,25 @@ defmodule PlateSlateWeb.Resolvers.Ordering do
     Enum.reduce(opts, msg, fn {key, value}, acc ->
       String.replace(acc, "%{#{key}}", to_string(value))
     end)
+  end
+
+  def ready_order(_, %{id: id}, _) do
+    order = Ordering.get_order!(id)
+
+    with {:ok, order} <- Ordering.update_order(order, %{state: "ready"}) do
+      {:ok, %{order: order}}
+    else
+      {:error, changeset} -> {:ok, %{errors: transform_errors(changeset)}}
+    end
+  end
+
+  def complete_order(_, %{id: id}, _) do
+    order = Ordering.get_order!(id)
+
+    with {:ok, order} <- Ordering.update_order(order, %{state: "complete"}) do
+      {:ok, %{order: order}}
+    else
+      {:error, changeset} -> {:ok, %{errors: transform_errors(changeset)}}
+    end
   end
 end

--- a/lib/plate_slate_web/resolvers/ordering.ex
+++ b/lib/plate_slate_web/resolvers/ordering.ex
@@ -1,0 +1,28 @@
+defmodule PlateSlateWeb.Resolvers.Ordering do
+  alias PlateSlate.Ordering
+
+  def place_order(_, %{input: place_order_input}, _) do
+    case Ordering.create_order(place_order_input) do
+      {:ok, order} -> 
+        Absinthe.Subscription.publish(PlateSlateWeb.Endpoint, order, new_order: "*")
+        {:ok, %{order: order}}
+      {:error, changeset} -> {:ok, %{errors: transform_errors(changeset)}}
+    end
+  end
+
+  defp transform_errors(changeset) do
+    changeset
+    |> Ecto.Changeset.traverse_errors(&format_error/1)
+    |> Enum.map(fn
+      {key, value} ->
+        %{key: key, message: value}
+    end)
+  end
+
+  @spec format_error(Ecto.Changeset.error()) :: String.t()
+  defp format_error({msg, opts}) do
+    Enum.reduce(opts, msg, fn {key, value}, acc ->
+      String.replace(acc, "%{#{key}}", to_string(value))
+    end)
+  end
+end

--- a/lib/plate_slate_web/router.ex
+++ b/lib/plate_slate_web/router.ex
@@ -27,7 +27,8 @@ defmodule PlateSlateWeb.Router do
 
     forward "/graphiql", Absinthe.Plug.GraphiQL,
       schema: PlateSlateWeb.Schema,
-      interface: :simple
+      interface: :simple,
+      socket: PlateSlateWeb.UserSocket
   end
 
   # Other scopes may use custom stacks.

--- a/lib/plate_slate_web/schema.ex
+++ b/lib/plate_slate_web/schema.ex
@@ -3,6 +3,7 @@ defmodule PlateSlateWeb.Schema do
   alias PlateSlateWeb.Resolvers
 
   import_types(__MODULE__.MenuTypes)
+  import_types(__MODULE__.OrderingTypes)
 
   enum :sort_order do
     value(:asc)
@@ -56,6 +57,11 @@ defmodule PlateSlateWeb.Schema do
 
   mutation do
     import_fields(:create_menu_item_query)
+
+    field :place_order, :order_result do
+      arg(:input, non_null(:place_order_input))
+      resolve(&Resolvers.Ordering.place_order/3)
+    end
   end
 
   object :menu_queries do
@@ -76,5 +82,11 @@ defmodule PlateSlateWeb.Schema do
   query do
     import_fields(:menu_queries)
     import_fields(:search_query)
+  end
+
+  subscription do
+    field :new_order, :order do
+      config(fn _args, _info -> {:ok, topic: "*"} end)
+    end
   end
 end

--- a/lib/plate_slate_web/schema.ex
+++ b/lib/plate_slate_web/schema.ex
@@ -62,6 +62,8 @@ defmodule PlateSlateWeb.Schema do
       arg(:input, non_null(:place_order_input))
       resolve(&Resolvers.Ordering.place_order/3)
     end
+
+    import_fields(:order_queries)
   end
 
   object :menu_queries do
@@ -79,6 +81,18 @@ defmodule PlateSlateWeb.Schema do
     end
   end
 
+  object :order_queries do
+    field :ready_order, :order_result do
+      arg(:id, non_null(:id))
+      resolve(&Resolvers.Ordering.ready_order/3)
+    end
+
+    field :complete_order, :order_result do
+      arg(:id, non_null(:id))
+      resolve(&Resolvers.Ordering.complete_order/3)
+    end
+  end
+
   query do
     import_fields(:menu_queries)
     import_fields(:search_query)
@@ -87,6 +101,22 @@ defmodule PlateSlateWeb.Schema do
   subscription do
     field :new_order, :order do
       config(fn _args, _info -> {:ok, topic: "*"} end)
+      # published by :place_order
+    end
+
+    field :update_order, :order do
+      arg(:id, non_null(:id))
+      config(fn args, _info -> {:ok, topic: args.id} end)
+
+      trigger([:ready_order, :complete_order],
+        topic: fn
+          %{order: order} -> [order.id]
+          # Errors are not published 
+          _ -> []
+        end
+      )
+
+      resolve(fn %{order: order}, _, _ -> {:ok, order} end)
     end
   end
 end

--- a/lib/plate_slate_web/schema.ex
+++ b/lib/plate_slate_web/schema.ex
@@ -41,8 +41,14 @@ defmodule PlateSlateWeb.Schema do
     field :category_id, non_null(:id)
   end
 
+  @desc "An error encountered trying to persist input"
+  object :input_error do
+    field :key, non_null(:string)
+    field :message, non_null(:string)
+  end
+
   object :create_menu_item_query do
-    field :create_menu_item, :menu_item do
+    field :create_menu_item, :menu_item_result do
       arg(:input, non_null(:menu_item_input))
       resolve(&Resolvers.Menu.create_item/3)
     end

--- a/lib/plate_slate_web/schema/menu_types.ex
+++ b/lib/plate_slate_web/schema/menu_types.ex
@@ -25,6 +25,11 @@ defmodule PlateSlateWeb.Schema.MenuTypes do
     field :price, :decimal
   end
 
+  object :menu_item_result do
+    field :menu_item, :menu_item
+    field :errors, list_of(:input_error)
+  end
+
   object :category do
     interfaces([:search_result])
     field :name, :string

--- a/lib/plate_slate_web/schema/ordering_types.ex
+++ b/lib/plate_slate_web/schema/ordering_types.ex
@@ -1,0 +1,30 @@
+defmodule PlateSlateWeb.Schema.OrderingTypes do
+  use Absinthe.Schema.Notation
+
+  input_object :order_item_input do
+    field :menu_item_id, non_null(:id)
+    field :quantity, non_null(:integer)
+  end
+
+  input_object :place_order_input do
+    field :customer_number, :integer
+    field :items, non_null(list_of(non_null(:order_item_input)))
+  end
+
+  object :order_result do
+    field :order, :order
+    field :errors, list_of(:input_error)
+  end
+
+  object :order do
+    field :id, :id
+    field :customer_number, :integer
+    field :items, list_of(:order_item)
+    field :state, :string
+  end
+
+  object :order_item do
+    field :name, :string
+    field :quantity, :integer
+  end
+end

--- a/priv/repo/migrations/20260220021928_create_orders.exs
+++ b/priv/repo/migrations/20260220021928_create_orders.exs
@@ -1,0 +1,14 @@
+defmodule PlateSlate.Repo.Migrations.CreateOrders do
+  use Ecto.Migration
+
+  def change do
+    create table(:orders) do
+      add :customer_number, :serial
+      add :items, :map
+      add :ordered_at, :utc_datetime, null: false, default: fragment("NOW()")
+      add :state, :string, null: false, default: "created"
+
+      timestamps(type: :utc_datetime)
+    end
+  end
+end

--- a/test/plate_slate/ordering_test.exs
+++ b/test/plate_slate/ordering_test.exs
@@ -1,0 +1,39 @@
+defmodule PlateSlate.OrderingTest do
+  use PlateSlate.DataCase, async: true
+
+  alias PlateSlate.Ordering
+
+  setup do
+    PlateSlate.Seeds.run()
+  end
+
+  describe "orders" do
+    alias PlateSlate.Ordering.Order
+
+    test "create_order/1 with valid data creates a order" do
+      chai = Repo.get_by!(PlateSlate.Menu.Item, name: "Masala Chai")
+      fries = Repo.get_by!(PlateSlate.Menu.Item, name: "French Fries")
+
+      attrs = %{
+        ordered_at: "2020-04-01 01:02:03",
+        state: "created",
+        items: [
+          %{menu_item_id: chai.id, quantity: 1},
+          %{menu_item_id: fries.id, quantity: 2}
+        ]
+      }
+
+      assert {:ok, %Order{} = order} = Ordering.create_order(attrs)
+
+      assert Enum.map(
+               order.items,
+               &Map.take(&1, [:name, :quantity, :price])
+             ) == [
+               %{name: "Masala Chai", quantity: 1, price: chai.price},
+               %{name: "French Fries", quantity: 2, price: fries.price}
+             ]
+
+      assert order.state == "created"
+    end
+  end
+end

--- a/test/plate_slate_web/schema/mutation/create_menu_item_test.exs
+++ b/test/plate_slate_web/schema/mutation/create_menu_item_test.exs
@@ -18,11 +18,17 @@ defmodule PlateSlateWeb.Schema.Mutation.CreateMenuItemTest do
   end
 
   @query """
-  mutation ($menuItem: MenuItemInput!) {
+    mutation ($menuItem: MenuItemInput!) {
     createMenuItem(input: $menuItem) {
-      name
-      description
-      price
+      errors {
+        key
+        message
+      }
+      menuItem {
+        name
+        description
+        price
+      }
     }
   }
   """
@@ -44,9 +50,12 @@ defmodule PlateSlateWeb.Schema.Mutation.CreateMenuItemTest do
     assert json_response(conn, 200) == %{
              "data" => %{
                "createMenuItem" => %{
-                 "name" => menu_item["name"],
-                 "description" => menu_item["description"],
-                 "price" => menu_item["price"]
+                 "errors" => nil,
+                 "menuItem" => %{
+                   "name" => menu_item["name"],
+                   "description" => menu_item["description"],
+                   "price" => menu_item["price"]
+                 }
                }
              }
            }
@@ -68,15 +77,17 @@ defmodule PlateSlateWeb.Schema.Mutation.CreateMenuItemTest do
         variables: %{"menuItem" => menu_item}
 
     assert json_response(conn, 200) == %{
-             "data" => %{"createMenuItem" => nil},
-             "errors" => [
-               %{
-                 "locations" => [%{"column" => 3, "line" => 2}],
-                 "message" => "Could not create menu item",
-                 "details" => %{"name" => ["has already been taken"]},
-                 "path" => ["createMenuItem"]
+             "data" => %{
+               "createMenuItem" => %{
+                 "menuItem" => nil,
+                 "errors" => [
+                   %{
+                     "message" => "has already been taken",
+                     "key" => "name"
+                   }
+                 ]
                }
-             ]
+             }
            }
   end
 end

--- a/test/plate_slate_web/schema/subscription/new_order_test.exs
+++ b/test/plate_slate_web/schema/subscription/new_order_test.exs
@@ -2,16 +2,39 @@ defmodule PlateSlateWeb.Schema.Subscription.NewOrderTest do
   use PlateSlateWeb.SubscriptionCase
 
   @subscription """
-
+  subscription {
+    newOrder {
+      customerNumber
+    }
+  }
   """
   @mutation """
-
+  mutation ($input: PlaceOrderInput!) {
+    placeOrder(inpute: $input) { order { id } }
+  }
   """
   test "", %{socket: socket} do
     # setup a subscription
+    ref = push_doc(socket, @subscription)
+    assert_reply(ref, :ok, %{subscriptionId: subscription_id})
 
     # make a mutation to trigger the subscription
+    order_input = %{
+      "customerNumber" => 24,
+      "items" => [%{"quantity" => 2, "menuItemId" => menu_item("Reuben").id}]
+    }
+
+    ref = push_doc(socket, @mutation, variables: %{"input" => order_input})
+    assert_reply ref, :ok, reply
+    assert %{data: %{"placeOrder" => %{"order" => %{"id" => _ }}}} = reply
 
     # check for subscription data
+    expected = %{
+      result: %{data: %{"newOrder" => %{"customerNumber" => 24}}},
+      subscriptionId: subscription_id
+    }
+
+    assert_push "subscription:data", push
+    assert expected == push
   end
 end

--- a/test/plate_slate_web/schema/subscription/new_order_test.exs
+++ b/test/plate_slate_web/schema/subscription/new_order_test.exs
@@ -10,10 +10,10 @@ defmodule PlateSlateWeb.Schema.Subscription.NewOrderTest do
   """
   @mutation """
   mutation ($input: PlaceOrderInput!) {
-    placeOrder(inpute: $input) { order { id } }
+    placeOrder(input: $input) { order { id } }
   }
   """
-  test "", %{socket: socket} do
+  test "new orders can be subscribed to", %{socket: socket} do
     # setup a subscription
     ref = push_doc(socket, @subscription)
     assert_reply(ref, :ok, %{subscriptionId: subscription_id})
@@ -26,7 +26,7 @@ defmodule PlateSlateWeb.Schema.Subscription.NewOrderTest do
 
     ref = push_doc(socket, @mutation, variables: %{"input" => order_input})
     assert_reply ref, :ok, reply
-    assert %{data: %{"placeOrder" => %{"order" => %{"id" => _ }}}} = reply
+    assert %{data: %{"placeOrder" => %{"order" => %{"id" => _}}}} = reply
 
     # check for subscription data
     expected = %{

--- a/test/plate_slate_web/schema/subscription/new_order_test.exs
+++ b/test/plate_slate_web/schema/subscription/new_order_test.exs
@@ -1,0 +1,17 @@
+defmodule PlateSlateWeb.Schema.Subscription.NewOrderTest do
+  use PlateSlateWeb.SubscriptionCase
+
+  @subscription """
+
+  """
+  @mutation """
+
+  """
+  test "", %{socket: socket} do
+    # setup a subscription
+
+    # make a mutation to trigger the subscription
+
+    # check for subscription data
+  end
+end

--- a/test/plate_slate_web/schema/subscription/update_order_test.exs
+++ b/test/plate_slate_web/schema/subscription/update_order_test.exs
@@ -1,0 +1,50 @@
+defmodule PlateSlateWeb.Schema.Subscription.UpdateOrderTest do
+  use PlateSlateWeb.SubscriptionCase
+
+  @subscription """
+  subscription ($id: ID!) {
+    updateOrder(id: $id) { state }
+  }
+  """
+  @mutation """
+  mutation ($id: ID!) {
+    readyOrder(id: $id) { errors { message } }
+  }
+  """
+  test "subscribe to order updates", %{socket: socket} do
+    reuben = menu_item("Reuben")
+
+    {:ok, order1} =
+      PlateSlate.Ordering.create_order(%{
+        customer_number: 123,
+        items: [%{menu_item_id: reuben.id, quantity: 2}]
+      })
+
+    {:ok, order2} =
+      PlateSlate.Ordering.create_order(%{
+        customer_number: 124,
+        items: [%{menu_item_id: reuben.id, quantity: 1}]
+      })
+
+    push_doc(socket, @subscription, variables: %{"id" => order1.id})
+    |> assert_reply(:ok, %{subscriptionId: _sub_ref1})
+
+    push_doc(socket, @subscription, variables: %{"id" => order2.id})
+    |> assert_reply(:ok, %{subscriptionId: sub_ref2})
+
+    push_doc(socket, @mutation, variables: %{"id" => order2.id})
+    |> assert_reply(:ok, reply)
+
+    refute reply[:errors]
+    refute reply[:data]["readyOrder"]["errors"]
+
+    assert_push("subscription:data", push)
+
+    expected = %{
+      result: %{data: %{"updateOrder" => %{"state" => "ready"}}},
+      subscriptionId: sub_ref2
+    }
+
+    assert expected == push
+  end
+end

--- a/test/support/channel_case.ex
+++ b/test/support/channel_case.ex
@@ -1,11 +1,11 @@
-#---
+# ---
 # Excerpted from "Craft GraphQL APIs in Elixir with Absinthe",
 # published by The Pragmatic Bookshelf.
 # Copyrights apply to this code. It may not be used to create training material,
 # courses, books, articles, and the like. Contact us if you are in doubt.
 # We make no guarantees that this code is fit for any purpose.
 # Visit http://www.pragmaticprogrammer.com/titles/wwgraphql for more book information.
-#---
+# ---
 defmodule PlateSlateWeb.ChannelCase do
   @moduledoc """
   This module defines the test case to be used by
@@ -33,13 +33,13 @@ defmodule PlateSlateWeb.ChannelCase do
     end
   end
 
-
   setup tags do
     :ok = Ecto.Adapters.SQL.Sandbox.checkout(PlateSlate.Repo)
+
     unless tags[:async] do
       Ecto.Adapters.SQL.Sandbox.mode(PlateSlate.Repo, {:shared, self()})
     end
+
     :ok
   end
-
 end

--- a/test/support/channel_case.ex
+++ b/test/support/channel_case.ex
@@ -1,0 +1,45 @@
+#---
+# Excerpted from "Craft GraphQL APIs in Elixir with Absinthe",
+# published by The Pragmatic Bookshelf.
+# Copyrights apply to this code. It may not be used to create training material,
+# courses, books, articles, and the like. Contact us if you are in doubt.
+# We make no guarantees that this code is fit for any purpose.
+# Visit http://www.pragmaticprogrammer.com/titles/wwgraphql for more book information.
+#---
+defmodule PlateSlateWeb.ChannelCase do
+  @moduledoc """
+  This module defines the test case to be used by
+  channel tests.
+
+  Such tests rely on `Phoenix.ChannelTest` and also
+  import other functionality to make it easier
+  to build common datastructures and query the data layer.
+
+  Finally, if the test case interacts with the database,
+  it cannot be async. For this reason, every test runs
+  inside a transaction which is reset at the beginning
+  of the test unless the test case is marked as async.
+  """
+
+  use ExUnit.CaseTemplate
+
+  using do
+    quote do
+      # Import conveniences for testing with channels
+      import Phoenix.ChannelTest
+
+      # The default endpoint for testing
+      @endpoint PlateSlateWeb.Endpoint
+    end
+  end
+
+
+  setup tags do
+    :ok = Ecto.Adapters.SQL.Sandbox.checkout(PlateSlate.Repo)
+    unless tags[:async] do
+      Ecto.Adapters.SQL.Sandbox.mode(PlateSlate.Repo, {:shared, self()})
+    end
+    :ok
+  end
+
+end

--- a/test/support/subscription_case.ex
+++ b/test/support/subscription_case.ex
@@ -13,7 +13,7 @@ defmodule PlateSlateWeb.SubscriptionCase do
       use PlateSlateWeb.ChannelCase
 
       use Absinthe.Phoenix.SubscriptionTest,
-        shcmea: PlateSlateWeb.Schema
+        schema: PlateSlateWeb.Schema
 
       setup do
         PlateSlate.Seeds.run()

--- a/test/support/subscriptioncase.ex
+++ b/test/support/subscriptioncase.ex
@@ -1,0 +1,36 @@
+defmodule PlateSlateWeb.SubscriptionCase do
+  @moduledoc """
+  his module defines the test case to be used by
+  subscription tests
+  """
+  require Phoenix.ChannelTest
+
+  use ExUnit.CaseTemplate
+
+  using do
+    quote do
+      # Import conveniences for testing with channels
+      use PlateSlateWeb.ChannelCase
+
+      use Absinthe.Phoenix.SubscriptionTest,
+        shcmea: PlateSlateWeb.Schema
+
+      setup do
+        PlateSlate.Seeds.run()
+
+        {:ok, socket} = Phoenix.ChannelTest.connect(PlateSlateWeb.UserSocket, %{})
+
+        {:ok, socket} = Absinthe.Phoenix.SubscriptionTest.join_absinthe(socket)
+
+        {:ok, socket: socket}
+      end
+
+      import unquote(__MODULE__), only: [menu_item: 1]
+    end
+  end
+
+  # handy function for grabbing a fixture
+  def menu_item(name) do
+    PlateSlate.Repo.get_by!(PlateSlate.Menu.Item, name: name)
+  end
+end


### PR DESCRIPTION
closes #19 

Adds DB schema, context, and GraphQL fields and tests for ordering lifecycle, including converting changeset errors to GraphQL error returns.